### PR TITLE
Fix some bugs for training and scale alignment

### DIFF
--- a/src/models/models/rasterization.py
+++ b/src/models/models/rasterization.py
@@ -179,11 +179,11 @@ class GaussianSplatRenderer(nn.Module):
             scale_factor = 1.0
             if "camera_poses" in context_predictions:
                 pred_context_extrinsic, _ = self.prepare_cameras(context_predictions, S)
-                scale_factor = pred_context_extrinsic[:, :, :3, 3].mean(dim=(1, 2), keepdim=True) / (
-                    pred_all_extrinsic[:, :S, :3, 3].mean(dim=(1, 2), keepdim=True) + 1e-6
+                scale_factor = pred_context_extrinsic[:, :, :3, 3].norm(dim=-1).mean(dim=1, keepdim=True) / (
+                    pred_all_extrinsic[:, :S, :3, 3].norm(dim=-1).mean(dim=1, keepdim=True) + 1e-6
                 )
 
-            pred_all_extrinsic[..., :3, 3] = pred_all_extrinsic[..., :3, 3] * scale_factor
+            pred_all_extrinsic[..., :3, 3] = pred_all_extrinsic[..., :3, 3] * scale_factor.unsqueeze(-1)
             render_viewmats, render_Ks = pred_all_extrinsic, pred_all_intrinsic
             valid_masks = views.get("valid_mask", torch.ones(B, S + V, H, W, dtype=bool, device=images.device))
         

--- a/training/configs/train/stage2.yaml
+++ b/training/configs/train/stage2.yaml
@@ -23,9 +23,9 @@ wrapper:
         gradient_loss_fn: grad
         valid_range: 0.98
       - _target_: training.losses.render.RenderMSELoss
-        mask_mode:  novel_mask
+        mask_mode:  target_mask
       - _target_: training.losses.render.RenderPerceptualLoss
-        mask_mode:  novel_mask
+        mask_mode:  target_mask
       - _target_: training.losses.render.RenderDepthLoss
         depth_head_sup: true
         depth_conf_mask: true
@@ -33,7 +33,7 @@ wrapper:
         alpha: 0.2
         gradient_loss_fn: grad
         valid_range: 0.98
-        mask_mode: source_mask + novel_mask 
+        mask_mode: context_mask + target_mask
     weights: [0.1, 1.0, 0.05, 0.1]
 
 data:

--- a/training/configs/wrapper/worldmirror.yaml
+++ b/training/configs/wrapper/worldmirror.yaml
@@ -71,9 +71,9 @@ train_criterion:
       gradient_loss_fn: grad
       valid_range: 0.98
     - _target_: training.losses.render.RenderMSELoss
-      mask_mode:  novel_mask
+      mask_mode:  target_mask
     - _target_: training.losses.render.RenderPerceptualLoss
-      mask_mode:  novel_mask
+      mask_mode:  target_mask
     - _target_: training.losses.render.RenderDepthLoss
       depth_head_sup: true
       depth_conf_mask: true
@@ -81,7 +81,7 @@ train_criterion:
       alpha: 0.2
       gradient_loss_fn: grad
       valid_range: 0.98
-      mask_mode: source_mask + novel_mask 
+      mask_mode: context_mask + target_mask
   weights: [5.0, 1.0, 1.0, 1.0, 0.1, 1.0, 0.05, 0.1]
 
 # log

--- a/training/losses/container.py
+++ b/training/losses/container.py
@@ -94,12 +94,12 @@ class LossContainer(nn.Module):
     def _skip_bad_case(self, total_loss, loss_dict):
         """Skip bad cases by zeroing out losses with NaN/Inf values"""
         # Zero out total loss if it contains NaN or Inf
-        total_loss = torch.zeros_like(total_loss)
+        total_loss = total_loss * 0.0
         
         # Zero out all loss dict values
         for key, val in list(loss_dict.items()):
             if torch.is_tensor(val):
-                loss_dict[key] = torch.zeros_like(val)
+                loss_dict[key] = val * 0.0
             elif isinstance(val, (float, int)):
                 loss_dict[key] = 0.0
         


### PR DESCRIPTION
Hi! I've made some improvements to the codebase to fix a few numerical and logical issues. Summary of changes:

1. **Scale Alignment Correction**: Update the `scale_factor` calculation. Previously, it used the average of translation components, which is now corrected by using the average of translation magnitudes (norms) to ensure a correct scale factor estimation between the coordinates of context frames and all frames.

2. **Gradient Propagation Fix**: In `_skip_bad_case`, replace `torch.zeros_like(total_loss)` with `total_loss * 0.0` to ensure gradient backpropagation.

3. **Config Refinement**: Standardize `mask_mode` names in the configuration (e.g., `novel_mask` -> `target_mask`) to maintain consistency with the rest of the pipeline.

Thank you for your contribution! WorldMirror is a fantastic piece of work. Hope these fixes are helpful!