### PR TITLE
Fix runtime errors for gsplat compatibility and large batch processing

### DIFF
--- a/src/models/models/rasterization.py
+++ b/src/models/models/rasterization.py
@@ -58,7 +58,6 @@ class Rasterizer:
             rasterize_mode=self.rasterization_mode,
             distributed=self.distributed,
             camera_model=self.camera_model,
-            with_eval3d=self.with_eval3d,
             render_mode="RGB+ED",
             **kwargs,
         )
@@ -67,6 +66,9 @@ class Rasterizer:
     def rasterize_batches(self, means, quats, scales, opacities, colors, viewmats, Ks, width, height, **kwargs):
         rendered_colors, rendered_depths, rendered_alphas = [], [], []
         batch_size = len(means)
+        # Ensure CUDA current device matches input tensors to avoid ordinal errors
+        if torch.cuda.is_available() and viewmats.is_cuda:
+            torch.cuda.set_device(viewmats.get_device())
         
         for i in range(batch_size):
             means_i = means[i]  # [N, 4]
@@ -176,7 +178,10 @@ class GaussianSplatRenderer(nn.Module):
         else:
             # Re-predict the camera for novel views and perform translation scale alignment
             pred_all_extrinsic, pred_all_intrinsic = self.prepare_cameras(predictions, S + V)
-            scale_factor = 1.0
+            # Default to a per-batch scale tensor so downstream math never hits Python floats
+            scale_factor = torch.ones(
+                (B, 1), device=pred_all_extrinsic.device, dtype=pred_all_extrinsic.dtype
+            )
             if "camera_poses" in context_predictions:
                 pred_context_extrinsic, _ = self.prepare_cameras(context_predictions, S)
                 scale_factor = pred_context_extrinsic[:, :, :3, 3].norm(dim=-1).mean(dim=1, keepdim=True) / (

--- a/src/utils/render_utils.py
+++ b/src/utils/render_utils.py
@@ -132,6 +132,16 @@ def render_interpolated_video(gs_renderer: GaussianSplatRenderer,
     # camtoworlds: [B, S, 4, 4], intrinsics: [B, S, 3, 3]
     b, s, _, _ = camtoworlds.shape
     h, w = hw
+    device = camtoworlds.device
+
+    # Ensure all splat tensors live on the same CUDA device as the cameras
+    def _move_splats_to_device(splats_dict, dev):
+        moved = {}
+        for k, v in splats_dict.items():
+            moved[k] = v.to(dev) if torch.is_tensor(v) else v
+        return moved
+
+    splats = _move_splats_to_device(splats, device)
 
     # Build interpolated trajectory
     def build_interpolated_traj(index, nums):

--- a/src/utils/save_utils.py
+++ b/src/utils/save_utils.py
@@ -147,8 +147,11 @@ def save_gs_ply(path: Path,
         opacities: Opacity values [N]
     """
     # Filter out points with scales greater than the 95th percentile
-    scale_threshold = torch.quantile(scales.max(dim=-1)[0], 0.95, dim=0)
-    filter_mask = scales.max(dim=-1)[0] <= scale_threshold
+    # Use numpy on CPU to avoid torch.quantile size limits
+    scale_max = scales.max(dim=-1)[0]
+    scale_max_np = scale_max.detach().cpu().float().numpy()
+    scale_threshold = float(np.quantile(scale_max_np, 0.95))
+    filter_mask = scale_max <= scale_threshold
 
     # Apply the filter to all tensors
     means = means[filter_mask].reshape(-1, 3)


### PR DESCRIPTION
## Summary

This PR fixes several runtime errors encountered when using WorldMirror with:
- Current gsplat versions (API changes)
- Multi-GPU systems
- Large batch inputs (300+ frames)

## Changes

- **Remove unsupported `with_eval3d` parameter** - This parameter is not available in the current gsplat version, causing AttributeError
- **Fix "float has no unsqueeze" error** - Changed `scale_factor` from Python float to tensor in `GaussianSplatRenderer`
- **Add explicit `torch.cuda.set_device()`** - Prevents device ordinal mismatch errors on multi-GPU systems
- **Move splat tensors to camera device** - Ensures all tensors are on the same CUDA device before rendering
- **Replace `torch.quantile` with numpy** - Handles large tensors (300+ frames) that exceed `torch.quantile` size limits

## Test plan

- [x] Tested with 320-frame video input
- [x] Tested on Blackwell GPU (SM120) with CUDA 12.8
- [x] Verified GLB and PLY output generation